### PR TITLE
🚀 feat: Add isLiked field to review API responses

### DIFF
--- a/backend/books/serializers.py
+++ b/backend/books/serializers.py
@@ -31,6 +31,7 @@ class ReviewSerializer(serializers.ModelSerializer):
     )
     likeCount = serializers.IntegerField(source="like_count", read_only=True)
     createdAt = serializers.DateTimeField(source="created_at", read_only=True)
+    isLiked = serializers.SerializerMethodField()
 
     class Meta:
         model = BookReview
@@ -44,6 +45,7 @@ class ReviewSerializer(serializers.ModelSerializer):
             "imageUrls",
             "likeCount",
             "createdAt",
+            "isLiked",
         ]
 
     def get_userProfile(self, obj):
@@ -56,6 +58,13 @@ class ReviewSerializer(serializers.ModelSerializer):
                 )
             return obj.reviewer.profile_picture.url
         return None
+
+    def get_isLiked(self, obj):
+        """Check if the current user has liked this review."""
+        request = self.context.get("request")
+        if request and request.user.is_authenticated:
+            return obj.helpful_votes.filter(id=request.user.id).exists()
+        return False
 
 
 class CreateReviewSerializer(serializers.Serializer):

--- a/backend/books/tests/test_views_likes.py
+++ b/backend/books/tests/test_views_likes.py
@@ -53,6 +53,7 @@ class ReviewLikeViewTestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("review", response.data)
         self.assertEqual(response.data["review"]["likeCount"], 1)
+        self.assertEqual(response.data["review"]["isLiked"], True)
 
         # Verify like was created in database
         self.assertTrue(
@@ -123,6 +124,7 @@ class ReviewUnlikeViewTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["review"]["likeCount"], 0)
+        self.assertEqual(response.data["review"]["isLiked"], False)
 
         # Verify like was removed from database
         self.assertFalse(
@@ -260,3 +262,84 @@ class ReviewMultipleLikesTestCase(APITestCase):
         self.assertEqual(
             ReviewHelpfulVote.objects.filter(review=self.review).count(), 0
         )
+
+
+class ReviewIsLikedFieldTestCase(APITestCase):
+    """Test cases for isLiked field in review responses."""
+
+    def setUp(self):
+        """Set up test data."""
+        self.user1 = User.objects.create_user(
+            username="testuser1",
+            email="test1@example.com",
+            password="testpass123",
+        )
+        self.user2 = User.objects.create_user(
+            username="testuser2",
+            email="test2@example.com",
+            password="testpass123",
+        )
+        self.review = BookReview.objects.create(
+            reviewer=self.user1,
+            book_title="Test Book",
+            author_name="Test Author",
+            content="Great book!",
+        )
+
+    def test_is_liked_false_when_not_liked(self):
+        """Test that isLiked is False when user hasn't liked the review."""
+        self.client.force_authenticate(user=self.user2)
+        url = reverse("books:user-reviews")
+
+        # Create a review by user2 to test
+        review2 = BookReview.objects.create(
+            reviewer=self.user2,
+            book_title="Another Book",
+            author_name="Another Author",
+            content="Good book!",
+        )
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Check that isLiked is False for the review
+        review_data = response.data["results"][0]
+        self.assertEqual(review_data["isLiked"], False)
+
+    def test_is_liked_true_when_liked(self):
+        """Test that isLiked is True when user has liked the review."""
+        # User2 creates a review
+        review2 = BookReview.objects.create(
+            reviewer=self.user2,
+            book_title="Another Book",
+            author_name="Another Author",
+            content="Good book!",
+        )
+
+        # User2 likes their own review
+        ReviewHelpfulVote.objects.create(review=review2, user=self.user2)
+
+        self.client.force_authenticate(user=self.user2)
+        url = reverse("books:user-reviews")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        review_data = response.data["results"][0]
+        self.assertEqual(review_data["isLiked"], True)
+
+    def test_is_liked_after_like_toggle(self):
+        """Test that isLiked updates correctly after toggling like."""
+        self.client.force_authenticate(user=self.user1)
+        like_url = reverse("books:review-like", kwargs={"pk": self.review.pk})
+
+        # Like the review
+        response = self.client.post(like_url)
+        self.assertEqual(response.data["review"]["isLiked"], True)
+
+        # Unlike the review
+        response = self.client.post(like_url)
+        self.assertEqual(response.data["review"]["isLiked"], False)
+
+        # Like again
+        response = self.client.post(like_url)
+        self.assertEqual(response.data["review"]["isLiked"], True)

--- a/backend/books/tests/test_views_reviews.py
+++ b/backend/books/tests/test_views_reviews.py
@@ -81,6 +81,7 @@ class ReviewListViewTestCase(APITestCase):
         self.assertIn("imageUrls", review_data)
         self.assertIn("likeCount", review_data)
         self.assertIn("createdAt", review_data)
+        self.assertIn("isLiked", review_data)
 
     def test_list_reviews_only_own_reviews(self):
         """Test that users only see their own reviews."""

--- a/backend/books/views.py
+++ b/backend/books/views.py
@@ -39,7 +39,7 @@ class UserReviewListCreateView(generics.ListCreateAPIView):
         """Return only the authenticated user's reviews."""
         return BookReview.objects.filter(
             reviewer=self.request.user
-        ).select_related("reviewer")
+        ).select_related("reviewer").prefetch_related("helpful_votes")
 
     @extend_schema(
         summary="List User's Reviews",
@@ -109,7 +109,9 @@ class ReviewLikeView(APIView):
     def post(self, request, pk):
         """Toggle like on a review."""
         try:
-            review = BookReview.objects.select_related("reviewer").get(pk=pk)
+            review = BookReview.objects.select_related(
+                "reviewer"
+            ).prefetch_related("helpful_votes").get(pk=pk)
         except BookReview.DoesNotExist:
             return Response(
                 {"error": "Review not found"},
@@ -127,6 +129,12 @@ class ReviewLikeView(APIView):
         else:
             # Like: add a new like
             ReviewHelpfulVote.objects.create(review=review, user=request.user)
+
+        # Refresh the review to get updated helpful_votes
+        review.refresh_from_db()
+        review = BookReview.objects.select_related(
+            "reviewer"
+        ).prefetch_related("helpful_votes").get(pk=pk)
 
         # Return updated review data
         serializer = ReviewSerializer(review, context={"request": request})

--- a/backend/docs/API_CONVENTIONS.md
+++ b/backend/docs/API_CONVENTIONS.md
@@ -117,15 +117,15 @@ POST   /auth/social/kakao/
 ```python
 # User's Book Reviews
 GET    /library/reviews/
-Response: {"results": [{"id": 1, "bookTitle": "...", ...}]}
+Response: {"results": [{"id": 1, "bookTitle": "...", "likeCount": 5, "isLiked": false, ...}]}
 
 POST   /library/reviews/
 Request:  {"bookTitle": "...", "authorName": "...", "content": "...", "imageUrls": [...]}
-Response: {"id": 1, "bookTitle": "...", "userName": "...", ...}
+Response: {"id": 1, "bookTitle": "...", "userName": "...", "likeCount": 0, "isLiked": false, ...}
 
 # Review Likes
 POST   /library/reviews/{id}/like/
-Response: {"review": {"id": 1, "likeCount": 5, ...}}
+Response: {"review": {"id": 1, "likeCount": 5, "isLiked": true, ...}}
 ```
 
 ### API Documentation (`/api/`)


### PR DESCRIPTION
## Summary

This PR adds the `isLiked` field to the book review API responses, enabling the frontend to display whether the authenticated user has liked each review. This change aligns the backend with the frontend implementation in PR #13 (`fix/front_integ` branch) and follows the same pattern used in the social feed's post like functionality.

The implementation includes query optimization using `prefetch_related` to prevent N+1 query issues and comprehensive test coverage for the new functionality.

## Changes Made

- **Added `isLiked` field to `ReviewSerializer`**
  - Implemented as `SerializerMethodField` that checks if the authenticated user has liked the review
  - Returns `False` for unauthenticated users
  - Follows the same pattern as `PostSerializer.get_isLiked()` in the social feed

- **Optimized database queries in `UserReviewListCreateView`**
  - Added `prefetch_related("helpful_votes")` to the queryset to avoid N+1 queries
  - Ensures efficient loading of like relationships when checking `isLiked` status

- **Optimized `ReviewLikeView` to return updated review data**
  - Added query optimization with `select_related` and `prefetch_related`
  - Refreshes review data after like/unlike to ensure accurate `isLiked` and `likeCount` values

- **Added comprehensive test coverage**
  - Created `ReviewIsLikedFieldTestCase` with 3 new test cases:
    - `test_is_liked_false_when_not_liked()` - Verifies `isLiked` is `False` for non-liked reviews
    - `test_is_liked_true_when_liked()` - Verifies `isLiked` is `True` for liked reviews
    - `test_is_liked_after_like_toggle()` - Verifies `isLiked` updates correctly when toggling
  - Updated existing tests to verify the presence of `isLiked` field

- **Updated API documentation**
  - Updated `backend/docs/API_CONVENTIONS.md` to include `isLiked` field in response examples
  - Documented the field in review list and like endpoints

## Pre-Submission Checklist

### Code Quality
- [x] Code follows project coding conventions
- [x] Self-review completed
- [x] Code is well-commented (especially complex logic)
- [x] No new warnings or errors
- [x] Code formatted: `make format` (N/A - using pre-commit hooks)
- [x] Linting passed: `make lint` (N/A - using pre-commit hooks)

### Testing Requirements
- [x] Tests added/updated for new functionality
- [x] All tests pass locally: `make test` (24/24 tests passing)
- [x] Test coverage ≥80% for new code
- [x] Integration tests added (if applicable)

### Documentation
- [x] Code documentation updated (docstrings, comments)
- [x] API documentation updated (if API changes)
- [ ] README updated (if setup/usage changes) - N/A
- [ ] **Design Documentation updated on Wiki** (if architectural changes) - N/A (minor field addition)
  - [ ] Revision history incremented
  - [ ] System architecture diagram updated (if applicable)
  - [ ] Class diagrams updated (frontend/backend, if applicable)
  - [ ] ER diagram updated (if database changes)
  - [ ] Testing plan updated (Iteration 3+)
  - Wiki: [Design Documentation](https://github.com/snuhcs-course/swpp-2025-project-team-10/wiki/Design-Documentation)

### Dependencies & Breaking Changes
- [x] No new dependencies (or justified below)
- [x] Dependencies pinned to specific versions
- [x] No breaking changes (or documented below)
- [x] Dependent changes merged and published

### SWPP Course Requirements
- [ ] Design Documentation updated for major changes - N/A (minor field addition)
- [ ] Testing plan updated (Iteration 3+) - Will update when required
- [ ] User acceptance test stories unchanged (after Iteration 3) - N/A

## Related Issues

Closes #13 (partially - backend portion)

**Note**: This PR addresses the backend portion of the `isLiked` field implementation. The frontend implementation is in PR #13 (`fix/front_integ` branch). However, there is a **response format mismatch** that needs to be addressed in the frontend PR (see Additional Context below).

## Screenshots / Demo

**Before**: Review API responses did not include `isLiked` field
```json
{
  "results": [
    {
      "id": 1,
      "bookTitle": "Test Book",
      "authorName": "Test Author",
      "userName": "testuser",
      "content": "Great book!",
      "likeCount": 5,
      "createdAt": "2025-10-19T10:00:00Z"
      // ❌ No isLiked field
    }
  ]
}
```

**After**: Review API responses include `isLiked` field
```json
{
  "results": [
    {
      "id": 1,
      "bookTitle": "Test Book",
      "authorName": "Test Author",
      "userName": "testuser",
      "content": "Great book!",
      "likeCount": 5,
      "createdAt": "2025-10-19T10:00:00Z",
      "isLiked": true  // ✅ New field
    }
  ]
}
```

**Test Results**:
```
24 passed in 7.27s
```

## Breaking Changes

None. This is a backward-compatible addition of a new field to the API response.

## Additional Context

### Frontend Integration Note

The frontend implementation in PR #13 (`fix/front_integ` branch) has a **response format mismatch** that needs to be addressed:

**Issue**: The frontend expects `Response<Review>` (direct Review object) from the like endpoint, but the backend returns `{"review": {...}}` (wrapped in an object), following the same pattern as the social feed's like endpoint.

**Backend Response** (current, correct):
```json
{
  "review": {
    "id": 1,
    "bookTitle": "...",
    "isLiked": true,
    ...
  }
}
```

**Frontend Expectation** (incorrect):
```kotlin
@POST("library/reviews/{id}/like/")
suspend fun toggleReviewLike(@Path("id") reviewId: Int): Response<Review>
// Should be: Response<ReviewLikeResponse>
```

**Recommendation**: The frontend should be updated to match the backend pattern by:
1. Creating a `ReviewLikeResponse` wrapper class similar to `LikeResponse` in the social feed
2. Updating the API interface to use `Response<ReviewLikeResponse>`
3. Extracting the review from the wrapper in the repository

This ensures consistency with the social feed's like endpoint pattern.

### Pattern Consistency

This implementation follows the exact same pattern as the social feed:
- `PostSerializer.get_isLiked()` → `ReviewSerializer.get_isLiked()`
- `prefetch_related("likes")` → `prefetch_related("helpful_votes")`
- Response format: `{"post": {...}}` → `{"review": {...}}`

---

## For Reviewers

### Review Focus Areas

1. **Query Optimization**: Verify that `prefetch_related("helpful_votes")` is correctly applied to prevent N+1 queries
2. **Test Coverage**: Review the new `ReviewIsLikedFieldTestCase` tests for completeness
3. **Pattern Consistency**: Confirm that the implementation matches the social feed's `isLiked` pattern
4. **Frontend Integration**: Note the response format mismatch mentioned in Additional Context

### Review Checklist
- [ ] Code quality and conventions followed
- [ ] Tests are comprehensive and pass
- [ ] Documentation is clear and complete
- [ ] No security vulnerabilities
- [ ] Performance impact considered (query optimization added)
- [ ] Design Documentation updated (if architectural changes) - N/A
- [ ] Changes align with project architecture
- [ ] Breaking changes properly documented - None

### Reviewer Comments
<!-- Reviewers: Add your feedback here -->

---

**Files Changed**:
- `backend/books/serializers.py` - Added `isLiked` field
- `backend/books/views.py` - Added query optimization
- `backend/books/tests/test_views_likes.py` - Added 3 new test cases
- `backend/books/tests/test_views_reviews.py` - Updated existing test
- `backend/docs/API_CONVENTIONS.md` - Updated documentation
